### PR TITLE
Change ‘open’ to ‘public’ where it’s necessary

### DIFF
--- a/Sources/EnumSpec.swift
+++ b/Sources/EnumSpec.swift
@@ -9,22 +9,22 @@
 import Foundation
 
 open class EnumSpec: TypeSpec {
-    open static let fieldModifiers: [Modifier] = [.Public, .Internal, .Fileprivate, .Private, .Static]
-    open static let methodModifiers: [Modifier] = [.Public, .Internal, .Fileprivate, .Private, .Static, .Throws]
-    open static let asMemberModifiers: [Modifier] = [.Public, .Internal, .Fileprivate, .Private]
+    public static let fieldModifiers: [Modifier] = [.Public, .Internal, .Fileprivate, .Private, .Static]
+    public static let methodModifiers: [Modifier] = [.Public, .Internal, .Fileprivate, .Private, .Static, .Throws]
+    public static let asMemberModifiers: [Modifier] = [.Public, .Internal, .Fileprivate, .Private]
 
     fileprivate init(builder: EnumSpecBuilder) {
         super.init(builder: builder as TypeSpecBuilder)
     }
 
-    open static func builder(for name: String) -> EnumSpecBuilder {
+    public static func builder(for name: String) -> EnumSpecBuilder {
         return EnumSpecBuilder(name: name)
     }
 }
 
 open class EnumSpecBuilder: TypeSpecBuilder, Builder {
     public typealias Result = EnumSpec
-    open static let defaultConstruct: Construct = .enum
+    public static let defaultConstruct: Construct = .enum
 
     fileprivate init(name: String) {
         super.init(name: name, construct: EnumSpecBuilder.defaultConstruct)

--- a/Sources/ExtensionSpec.swift
+++ b/Sources/ExtensionSpec.swift
@@ -9,22 +9,22 @@
 import Foundation
 
 open class ExtensionSpec: TypeSpec {
-    open static let fieldModifiers: [Modifier] = [.Public, .Internal, .Fileprivate, .Private, .Static, .Final, .Override, .Required]
-    open static let methodModifiers: [Modifier] = [.Public, .Internal, .Fileprivate, .Private, .Static, .Final, .Klass, .Throws, .Convenience, .Override, .Required]
-    open static let asMemberModifiers: [Modifier] = [.Public, .Internal, .Fileprivate, .Private]
+    public static let fieldModifiers: [Modifier] = [.Public, .Internal, .Fileprivate, .Private, .Static, .Final, .Override, .Required]
+    public static let methodModifiers: [Modifier] = [.Public, .Internal, .Fileprivate, .Private, .Static, .Final, .Klass, .Throws, .Convenience, .Override, .Required]
+    public static let asMemberModifiers: [Modifier] = [.Public, .Internal, .Fileprivate, .Private]
 
     fileprivate init(builder: ExtensionSpecBuilder) {
         super.init(builder: builder as TypeSpecBuilder)
     }
 
-    open static func builder(for name: String) -> ExtensionSpecBuilder {
+    public static func builder(for name: String) -> ExtensionSpecBuilder {
         return ExtensionSpecBuilder(name: name)
     }
 }
 
 open class ExtensionSpecBuilder: TypeSpecBuilder, Builder {
     public typealias Result = ExtensionSpec
-    open static let defaultConstruct: Construct = .extension
+    public static let defaultConstruct: Construct = .extension
 
     public init(name: String) {
         super.init(name: name, construct: ExtensionSpecBuilder.defaultConstruct)

--- a/Sources/FieldSpec.swift
+++ b/Sources/FieldSpec.swift
@@ -17,8 +17,8 @@ public protocol FieldSpecType {
 }
 
 open class FieldSpec: PoetSpec, FieldSpecType {
-    open let type: TypeName?
-    open let initializer: CodeBlock?
+    public let type: TypeName?
+    public let initializer: CodeBlock?
     open var parentType: Construct?
     open var associatedValues: [TypeName]?
     open var nameCase: String.Case?
@@ -35,7 +35,7 @@ open class FieldSpec: PoetSpec, FieldSpecType {
                    imports: builder.imports)
     }
 
-    open static func builder(for name: String, type: TypeName? = nil, construct: Construct? = nil) -> FieldSpecBuilder {
+    public static func builder(for name: String, type: TypeName? = nil, construct: Construct? = nil) -> FieldSpecBuilder {
         return FieldSpecBuilder(name: name, type: type, construct: construct)
     }
 
@@ -155,7 +155,7 @@ open class FieldSpecBuilder: PoetSpecBuilder, Builder, FieldSpecType {
     
     public typealias Result = FieldSpec
 
-    open let type: TypeName?
+    public let type: TypeName?
     open fileprivate(set) var initializer: CodeBlock? = nil
     open var parentType: Construct?
     open var associatedValues: [TypeName]?

--- a/Sources/MethodSpec.swift
+++ b/Sources/MethodSpec.swift
@@ -18,11 +18,11 @@ public protocol MethodSpecProtocol {
 }
 
 open class MethodSpec: PoetSpec, MethodSpecProtocol {
-    open let typeVariables: [TypeName]
-    open let throwsError: Bool
-    open let returnType: TypeName?
-    open let parameters: [ParameterSpec]
-    open let codeBlock: CodeBlock?
+    public let typeVariables: [TypeName]
+    public let throwsError: Bool
+    public let returnType: TypeName?
+    public let parameters: [ParameterSpec]
+    public let codeBlock: CodeBlock?
     open var parentType: Construct?
 
     fileprivate init(builder: MethodSpecBuilder) {
@@ -37,7 +37,7 @@ open class MethodSpec: PoetSpec, MethodSpecProtocol {
                    description: builder.description, generatorInfo: builder.generatorInfo, framework: builder.framework, imports: builder.imports)
     }
 
-    open static func builder(for name: String) -> MethodSpecBuilder {
+    public static func builder(for name: String) -> MethodSpecBuilder {
         return MethodSpecBuilder(name: name)
     }
 
@@ -117,7 +117,7 @@ open class MethodSpec: PoetSpec, MethodSpecProtocol {
 
 open class MethodSpecBuilder: PoetSpecBuilder, Builder, MethodSpecProtocol {
     public typealias Result = MethodSpec
-    open static let defaultConstruct: Construct = .method
+    public static let defaultConstruct: Construct = .method
 
     open fileprivate(set) var typeVariables = [TypeName]()
     open fileprivate(set) var throwsError = false

--- a/Sources/Modifier.swift
+++ b/Sources/Modifier.swift
@@ -10,27 +10,27 @@ import Foundation
 
 open class Modifier: NSObject {
 
-    open let rawString: String
+    public let rawString: String
 
     public init(rawString: String) {
         self.rawString = rawString
     }
 
-    open static let Open = Modifier(rawString: "open")
-    open static let Public = Modifier(rawString: "public")
-    open static let Internal = Modifier(rawString: "internal")
-    open static let Fileprivate = Modifier(rawString: "fileprivate")
-    open static let Private = Modifier(rawString: "private")
+    public static let Open = Modifier(rawString: "open")
+    public static let Public = Modifier(rawString: "public")
+    public static let Internal = Modifier(rawString: "internal")
+    public static let Fileprivate = Modifier(rawString: "fileprivate")
+    public static let Private = Modifier(rawString: "private")
 
-    open static let Static = Modifier(rawString: "static")
-    open static let Final = Modifier(rawString: "final")
-    open static let Klass = Modifier(rawString: "class")
+    public static let Static = Modifier(rawString: "static")
+    public static let Final = Modifier(rawString: "final")
+    public static let Klass = Modifier(rawString: "class")
 
-    open static let Mutating = Modifier(rawString: "mutating")
-    open static let Throws = Modifier(rawString: "throws")
-    open static let Convenience = Modifier(rawString: "convenience")
-    open static let Override = Modifier(rawString: "override")
-    open static let Required = Modifier(rawString: "required")
+    public static let Mutating = Modifier(rawString: "mutating")
+    public static let Throws = Modifier(rawString: "throws")
+    public static let Convenience = Modifier(rawString: "convenience")
+    public static let Override = Modifier(rawString: "override")
+    public static let Required = Modifier(rawString: "required")
 
     open override var hashValue: Int {
         return rawString.hashValue
@@ -42,7 +42,7 @@ open class Modifier: NSObject {
     //    case Weak
     //    case Optional
 
-    open static func equivalentAccessLevel(parentModifiers pm: Set<Modifier>, childModifiers cm: Set<Modifier>)
+    public static func equivalentAccessLevel(parentModifiers pm: Set<Modifier>, childModifiers cm: Set<Modifier>)
         -> Bool
     {
         let parentAccessLevel = Modifier.accessLevel(pm)
@@ -69,7 +69,7 @@ open class Modifier: NSObject {
         return false
     }
 
-    open static func accessLevel(_ modifiers: Set<Modifier>)
+    public static func accessLevel(_ modifiers: Set<Modifier>)
         -> Modifier
     {
         if modifiers.contains(.Private) {

--- a/Sources/ParameterSpec.swift
+++ b/Sources/ParameterSpec.swift
@@ -14,9 +14,9 @@ public protocol ParameterSpecProtocol {
 }
 
 open class ParameterSpec: PoetSpec, ParameterSpecProtocol {
-    open let label: String?
-    open let type: TypeName
-    open let initializer: CodeBlock?
+    public let label: String?
+    public let type: TypeName
+    public let initializer: CodeBlock?
 
     fileprivate init(builder: ParameterSpecBuilder) {
         self.label = builder.label
@@ -26,7 +26,7 @@ open class ParameterSpec: PoetSpec, ParameterSpecProtocol {
                 description: builder.description, generatorInfo: builder.generatorInfo, framework: builder.framework, imports: builder.imports)
     }
 
-    open static func builder(for name: String, label: String? = nil, type: TypeName, construct: Construct? = nil) -> ParameterSpecBuilder {
+    public static func builder(for name: String, label: String? = nil, type: TypeName, construct: Construct? = nil) -> ParameterSpecBuilder {
         return ParameterSpecBuilder(name: name, label: label, type: type, construct: construct)
     }
 
@@ -58,11 +58,11 @@ open class ParameterSpec: PoetSpec, ParameterSpecProtocol {
 
 open class ParameterSpecBuilder: PoetSpecBuilder, Builder, ParameterSpecProtocol {
     public typealias Result = ParameterSpec
-    open static let defaultConstruct: Construct = .param
+    public static let defaultConstruct: Construct = .param
     open fileprivate(set) var initializer: CodeBlock? = nil
 
-    open let label: String?
-    open let type: TypeName
+    public let label: String?
+    public let type: TypeName
 
     fileprivate init(name: String, label: String? = nil, type: TypeName, construct: Construct? = nil) {
         self.label = label

--- a/Sources/PoetSpec.swift
+++ b/Sources/PoetSpec.swift
@@ -20,14 +20,14 @@ public protocol PoetSpecType {
 }
 
 open class PoetSpec: PoetSpecType, Emitter, Importable {
-    open let name: String
-    open let construct: Construct
-    open let modifiers: Set<Modifier>
-    open let description: String?
-    open let generatorInfo: String?
-    open let framework: String?
-    open let imports: Set<String>
-    open let key: UUID // Unique key for equality checking
+    public let name: String
+    public let construct: Construct
+    public let modifiers: Set<Modifier>
+    public let description: String?
+    public let generatorInfo: String?
+    public let framework: String?
+    public let imports: Set<String>
+    public let key: UUID // Unique key for equality checking
 
     public init(name: String, construct: Construct, modifiers: Set<Modifier>, description: String?, generatorInfo: String?, framework: String?, imports: Set<String>) {
         self.name = name
@@ -70,8 +70,8 @@ extension PoetSpec: Hashable {
 }
 
 open class PoetSpecBuilder: PoetSpecType {
-    open let name: String
-    open let construct: Construct
+    public let name: String
+    public let construct: Construct
     open fileprivate(set) var modifiers = Set<Modifier>()
     open fileprivate(set) var description: String? = nil
     open fileprivate(set) var generatorInfo: String? = nil

--- a/Sources/ProtocolSpec.swift
+++ b/Sources/ProtocolSpec.swift
@@ -9,22 +9,22 @@
 import Foundation
 
 open class ProtocolSpec: TypeSpec {
-    open static let fieldModifiers: [Modifier] = [.Static]
-    open static let methodModifiers: [Modifier] = [.Static]
-    open static let asMemberModifiers: [Modifier] = [.Public, .Internal, .Fileprivate, .Private]
+    public static let fieldModifiers: [Modifier] = [.Static]
+    public static let methodModifiers: [Modifier] = [.Static]
+    public static let asMemberModifiers: [Modifier] = [.Public, .Internal, .Fileprivate, .Private]
 
     fileprivate init(builder: ProtocolSpecBuilder) {
         super.init(builder: builder as TypeSpecBuilder)
     }
 
-    open static func builder(for name: String) -> ProtocolSpecBuilder {
+    public static func builder(for name: String) -> ProtocolSpecBuilder {
         return ProtocolSpecBuilder(name: name)
     }
 }
 
 open class ProtocolSpecBuilder: TypeSpecBuilder, Builder {
     public typealias Result = ProtocolSpec
-    open static let defaultConstruct: Construct = .protocol
+    public static let defaultConstruct: Construct = .protocol
 
     public init(name: String) {
         super.init(name: name, construct: ProtocolSpecBuilder.defaultConstruct)

--- a/Sources/StructSpec.swift
+++ b/Sources/StructSpec.swift
@@ -9,22 +9,22 @@
 import Foundation
 
 open class StructSpec: TypeSpec {
-    open static let fieldModifiers: [Modifier] = [.Public, .Internal, .Fileprivate, .Private, .Static]
-    open static let methodModifiers: [Modifier] = [.Public, .Internal, .Fileprivate, .Private, .Static, .Mutating, .Throws]
-    open static let asMemberModifiers: [Modifier] = [.Public, .Internal, .Fileprivate, .Private]
+    public static let fieldModifiers: [Modifier] = [.Public, .Internal, .Fileprivate, .Private, .Static]
+    public static let methodModifiers: [Modifier] = [.Public, .Internal, .Fileprivate, .Private, .Static, .Mutating, .Throws]
+    public static let asMemberModifiers: [Modifier] = [.Public, .Internal, .Fileprivate, .Private]
 
     fileprivate init(builder: StructSpecBuilder) {
         super.init(builder: builder as TypeSpecBuilder)
     }
 
-    open static func builder(for name: String) -> StructSpecBuilder {
+    public static func builder(for name: String) -> StructSpecBuilder {
         return StructSpecBuilder(name: name)
     }
 }
 
 open class StructSpecBuilder: TypeSpecBuilder, Builder {
     public typealias Result = StructSpec
-    open static let defaultConstruct: Construct = .struct
+    public static let defaultConstruct: Construct = .struct
     fileprivate var includeInit: Bool = false
 
     public init(name: String) {

--- a/Sources/TypeName.swift
+++ b/Sources/TypeName.swift
@@ -24,9 +24,9 @@ open class TypeReferenceName: TypeName {
 }
 
 open class TypeName: Importable {
-    open let keyword: String
-    open let attributes: [String]
-    open let innerTypes: [TypeName]
+    public let keyword: String
+    public let attributes: [String]
+    public let innerTypes: [TypeName]
 
     // for arrays and dictionaries
     open var leftInnerType: TypeName? {
@@ -38,7 +38,7 @@ open class TypeName: Importable {
         guard innerTypes.count > 1 else { return nil }
         return innerTypes[1]
     }
-    open let optional: Bool
+    public let optional: Bool
     open var imports: Set<String>
 
     public required convenience init<T: StringProtocol>(keyword: T, attributes: [String] = [], optional: Bool = false, imports: [String]? = nil)

--- a/Sources/TypeSpec.swift
+++ b/Sources/TypeSpec.swift
@@ -17,11 +17,11 @@ public protocol TypeSpecProtocol {
 }
 
 open class TypeSpec: PoetSpec, TypeSpecProtocol {
-    open let methods: [MethodSpec]
-    open let fields: [FieldSpec]
-    open let superType: TypeName?
-    open let protocols: [TypeName]
-    open let nestedTypes: [TypeSpec]
+    public let methods: [MethodSpec]
+    public let fields: [FieldSpec]
+    public let superType: TypeName?
+    public let protocols: [TypeName]
+    public let nestedTypes: [TypeSpec]
 
     public init(builder: TypeSpecBuilder) {
         methods = builder.methods


### PR DESCRIPTION
Using the latest Xcode, the following warning showed up often:
“'let' properties are implicitly 'final'; use 'public' instead of 'open’”

This makes sense because `let` properties and static methods can’t be overridden. If the intent of using `open` was to expose them to the public, `public` should be used.

This PR changes all of the instances caught by Xcode.